### PR TITLE
Add switch to place plotarea on the canvas

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ To plot figures within the `Plotarea`, ceate an instance of `Canvas` with the pa
 
 `viewport` is the definition of the visible area of the xy-plane, which consists of arrays of x and y ranges.
 
-`plotarea` has four attributes: `offset`, `width`, `height` and `backgroundColor`.
+`plotarea` has five attributes: `offset`, `width`, `height`, `backgroundColor` and `placeAutomatically`.
 
 ```php
 <?php
@@ -319,6 +319,7 @@ $canvas = Plotter::make(
         'width' => 640, // in pix, default=(80% of the canvas)
         'height' => 360 // in pix, default=(80% of the canvas)
         'backgroundColor' => '#dddddd', // defautl='#ffffff'
+        'placeAutomatically' => false, // default=true
     ],
     backgroundColor: '#0000cc',  // optional, default='#ffffff'
 );
@@ -333,6 +334,17 @@ Now, you can plot figures within the `Plotarea` by using `plot*` methods with co
 // borderColor: '#0000ff'
 $canvas
     ->plotBox(-3.5, 4.2, 2.5, 2.3, '#ffff99', 1, '#0000ff')
+    ->save('img/HandlingPlotarea.png');
+```
+
+When you set `$plotarea['placeAutomatically']` as `false`, you need to use `placePlotarea()` method to place `Plotarea` on the `Canvas` after using `plot*` methods.
+
+This is expected to avoid slowdowns when using the `plot*` methods frequently, and unexpected results when making the background of `Plotarea` transparent.
+
+```php
+$canvas
+    ->plotBox(-3.5, 4.2, 2.5, 2.3, '#ffff99', 1, '#0000ff')
+    ->placePlotarea()
     ->save('img/HandlingPlotarea.png');
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "macocci7/php-plotter2d",
     "description": "A PHP Library to plot graphs and figures on a xy(-two-dimensional)-plane.",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "type": "library",
     "license": "MIT",
     "autoload": {

--- a/examples/PlotWithinPlotarea.php
+++ b/examples/PlotWithinPlotarea.php
@@ -11,6 +11,7 @@ $plotarea = [
     //'width' => 420,
     //'height' => 280,
     //'backgroundColor' => null, // transparent
+    'placeAutomatically' => false,
 ];
 
 $canvas = Plotter::make(
@@ -73,6 +74,7 @@ $canvas
         borderColor: '#009900',
     )
     ->plotText('y = x', 3, 5, 24)
+    ->placePlotarea()
     ->drawText('Plotting within the Plotarea', 90, 20, 34, '', '#333333', 'left', 'top')
     // frame of the ploarea
     ->drawBox(

--- a/src/Canvas.php
+++ b/src/Canvas.php
@@ -82,7 +82,10 @@ class Canvas
     {
         if (str_starts_with($name, 'plot')) {
             $this->plotareaClass->{$name}(...$arguments);
-            $this->placePlotarea();
+            $place = $this->plotarea['placeAutomatically'] ?? true;
+            if ($place) {
+                $this->placePlotarea();
+            }
             return $this;
         }
         throw new \Exception("Call to Undefined method {$name}.");
@@ -174,7 +177,7 @@ class Canvas
      * places(overwrites) the plotarea on the canvas
      *
      */
-    private function placePlotarea(): void
+    public function placePlotarea(): self
     {
         $this->image->place(
             element: $this->plotareaClass->getImage(),
@@ -182,6 +185,7 @@ class Canvas
             offset_x: $this->plotarea['offset'][0],
             offset_y: $this->plotarea['offset'][1],
         );
+        return $this;
     }
 
     /**


### PR DESCRIPTION
This PR:

- Adds the `placeAutomatically` attribute to `Plotarea`
- Updates `Canvas` to place `Plotarea` on the `Canvas` only when `placeAutomatically` is `true`
- Changes method visibility of `Canvas::placePlotarea` to `public`
- Updates examples and README